### PR TITLE
인증 로직 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,7 +42,7 @@ android {
 dependencies {
     implementation(project(":domain"))
 
-    implementation(Library.AndroidX.COROUTINE)
+    implementation(Library.Coroutine.COROUTINE)
     implementation(Library.AndroidX.CORE_KTX)
     implementation(Library.AndroidX.APPCOMPAT)
     implementation(Library.AndroidX.MATERIAL)
@@ -56,7 +56,7 @@ dependencies {
     androidTestImplementation(Library.AndroidX.TEST_JUNIT)
     androidTestImplementation(Library.AndroidX.ESPRESSO)
 
-    testImplementation(Library.Junit.JUNIT)
+    testImplementation(Library.Junit.JUNIT4)
 
     implementation(Library.Network.RETROFIT)
     implementation(Library.Network.MOSHI)

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,6 @@ object Version {
 
 object Library {
     object AndroidX {
-        const val COROUTINE = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Version.COROUTINE}"
         const val CORE_KTX = "androidx.core:core-ktx:${Version.CORE_KTX}"
         const val APPCOMPAT = "androidx.appcompat:appcompat:${Version.APPCOMPAT}"
         const val MATERIAL = "com.google.android.material:material:${Version.MATERIAL}"
@@ -45,7 +44,11 @@ object Library {
     }
 
     object Junit {
-        const val JUNIT = "junit:junit:${Version.JUNIT}"
+        const val JUNIT4 = "junit:junit:${Version.JUNIT}"
+        const val JUNIT5 = "org.junit.jupiter:junit-jupiter:5.7.2"
+        const val junitVintageEngine = "org.junit.vintage:junit-vintage-engine:5.7.2"
+        const val TRUTH = "com.google.truth:truth:1.1.2"
+        const val MOCKK = "io.mockk:mockk:1.12.0"
     }
 
     object Network {
@@ -54,11 +57,20 @@ object Library {
         const val MOSHI_KOTLIN = "com.squareup.moshi:moshi-kotlin:${Version.MOSHI}"
         const val OKHTTP = "com.squareup.okhttp3:okhttp:${Version.OKHTTP}"
         const val LOGGING_INTERCEPTOR = "com.squareup.okhttp3:logging-interceptor:${Version.OKHTTP}"
+        const val MOCKWEBSERVER = "com.squareup.okhttp3:mockwebserver:${Version.OKHTTP}"
     }
 
     object Hilt {
         const val HILT = "com.google.dagger:hilt-android:${Version.HILT}"
         const val HILT_COMPILER = "com.google.dagger:hilt-android-compiler:${Version.HILT}"
+        const val CORE = "com.google.dagger:hilt-core:${Version.HILT}"
+        const val COMPILER = "com.google.dagger:hilt-compiler:${Version.HILT}"
+    }
+
+    object Coroutine {
+        const val COROUTINE = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Version.COROUTINE}"
+        const val CORE = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Version.COROUTINE}"
+        const val TEST = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
     }
 
     object Glide {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,13 +1,35 @@
 plugins {
     id("java-library")
     id("org.jetbrains.kotlin.jvm")
+    id("kotlin")
+    kotlin("kapt")
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 dependencies {
     implementation(project(":domain"))
+    implementation(Library.Network.RETROFIT)
+    implementation(Library.Network.MOSHI)
+    implementation(Library.Network.MOSHI_KOTLIN)
+    implementation(Library.Network.LOGGING_INTERCEPTOR)
+    implementation(Library.Network.OKHTTP)
+
+    implementation(Library.Hilt.CORE)
+    kapt(Library.Hilt.COMPILER)
+
+    implementation(Library.Coroutine.CORE)
+    implementation(Library.Coroutine.TEST)
+
+    testImplementation(Library.Junit.JUNIT5)
+    testImplementation(Library.Junit.TRUTH)
+    testImplementation(Library.Junit.MOCKK)
+    testImplementation(Library.Network.MOCKWEBSERVER)
 }

--- a/data/src/main/java/com/woowa/data/MyClass.kt
+++ b/data/src/main/java/com/woowa/data/MyClass.kt
@@ -1,4 +1,0 @@
-package com.woowa.data
-
-class MyClass {
-}

--- a/data/src/main/java/com/woowa/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/woowa/data/di/NetworkModule.kt
@@ -1,4 +1,4 @@
-package com.dnd.niceteam.di
+package com.woowa.data.di
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -13,9 +13,9 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
-@Module
 @InstallIn(SingletonComponent::class)
-object NetworkModule {
+@Module
+internal object NetworkModule {
 
     private const val BASE_URL = "http://3.34.243.94:8080/"
 
@@ -25,7 +25,7 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun getOkHttpClient(): OkHttpClient {
+    fun provideOkHttpClient(): OkHttpClient {
         val loggingInterceptor =
             HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BODY }
         return OkHttpClient.Builder()
@@ -38,7 +38,7 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun getRetrofit(okHttpClient: OkHttpClient): Retrofit {
+    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
         val moshi = Moshi.Builder()
             .add(KotlinJsonAdapterFactory())
             .build()

--- a/data/src/main/java/com/woowa/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/woowa/data/di/RepositoryModule.kt
@@ -1,0 +1,18 @@
+package com.woowa.data.di
+
+import com.woowa.data.remote.repository.AuthenticationRepositoryImpl
+import com.woowa.domain.repository.AuthenticationRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+internal interface RepositoryModule {
+
+    @Binds
+    @Singleton
+    fun provideAuthentication(authenticationRepositoryImpl: AuthenticationRepositoryImpl): AuthenticationRepository
+}

--- a/data/src/main/java/com/woowa/data/di/ServiceModule.kt
+++ b/data/src/main/java/com/woowa/data/di/ServiceModule.kt
@@ -1,0 +1,20 @@
+package com.woowa.data.di
+
+import com.woowa.data.remote.service.AuthenticationService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+internal object ServiceModule {
+
+    @Provides
+    @Singleton
+    fun provideAuthenticationService(retrofit: Retrofit): AuthenticationService {
+        return retrofit.create(com.woowa.data.remote.service.AuthenticationService::class.java)
+    }
+}

--- a/data/src/main/java/com/woowa/data/remote/model/response/ApiResponse.kt
+++ b/data/src/main/java/com/woowa/data/remote/model/response/ApiResponse.kt
@@ -1,0 +1,3 @@
+package com.woowa.data.remote.model.response
+
+internal data class ApiResponse<T>(val success: Boolean, val data: T? = null, val error: ErrorResponse = ErrorResponse.of())

--- a/data/src/main/java/com/woowa/data/remote/model/response/ErrorResponse.kt
+++ b/data/src/main/java/com/woowa/data/remote/model/response/ErrorResponse.kt
@@ -1,0 +1,14 @@
+package com.woowa.data.remote.model.response
+
+import com.woowa.domain.model.error.FieldError
+
+internal data class ErrorResponse(val code: String, val message: String, val errors: List<FieldError>) {
+
+    companion object {
+        fun of(): ErrorResponse = ErrorResponse(
+            code = "",
+            message = "",
+            errors = emptyList()
+        )
+    }
+}

--- a/data/src/main/java/com/woowa/data/remote/model/response/TokenDto.kt
+++ b/data/src/main/java/com/woowa/data/remote/model/response/TokenDto.kt
@@ -1,0 +1,8 @@
+package com.woowa.data.remote.model.response
+
+import com.woowa.domain.model.Token
+
+internal data class TokenDto(val accessToken: String, val refreshToken: String) {
+    fun toToken(): Token = Token(accessToken, refreshToken)
+}
+

--- a/data/src/main/java/com/woowa/data/remote/repository/AuthenticationRepositoryImpl.kt
+++ b/data/src/main/java/com/woowa/data/remote/repository/AuthenticationRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.woowa.data.remote.repository
+
+import com.woowa.data.remote.service.AuthenticationService
+import com.woowa.domain.model.*
+import com.woowa.domain.repository.AuthenticationRepository
+import javax.inject.Inject
+
+internal class AuthenticationRepositoryImpl @Inject constructor(
+    private val auth: AuthenticationService
+): AuthenticationRepository {
+
+    override suspend fun login(login: Login): ApiResult<Token> {
+        val token = auth.login(login)
+        return ApiResult(
+            token.success,
+            token.data?.toToken(),
+            ErrorResult.of(token.error.message, token.error.errors)
+        )
+    }
+
+    override suspend fun logout(): ApiResult<*> {
+        val result = auth.logout()
+        return ApiResult(result.success, null)
+    }
+
+    override suspend fun reissue(reissue: Reissue): ApiResult<Token> {
+        val token = auth.reissue(reissue)
+        return ApiResult(
+            token.success,
+            token.data?.toToken(),
+            ErrorResult.of(token.error.message, token.error.errors)
+        )
+    }
+}

--- a/data/src/main/java/com/woowa/data/remote/service/AuthenticationService.kt
+++ b/data/src/main/java/com/woowa/data/remote/service/AuthenticationService.kt
@@ -1,0 +1,20 @@
+package com.woowa.data.remote.service
+
+import com.woowa.data.remote.model.response.ApiResponse
+import com.woowa.data.remote.model.response.TokenDto
+import com.woowa.domain.model.Login
+import com.woowa.domain.model.Reissue
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+internal interface AuthenticationService {
+
+    @POST("/login")
+    suspend fun login(@Body login: Login): ApiResponse<TokenDto>
+
+    @POST("/logout")
+    suspend fun logout(): ApiResponse<*>
+
+    @POST("/auth/reissue")
+    suspend fun reissue(@Body reissue: Reissue): ApiResponse<TokenDto>
+}

--- a/data/src/test/java/com/woowa/data/remote/service/AuthenticationServiceTest.kt
+++ b/data/src/test/java/com/woowa/data/remote/service/AuthenticationServiceTest.kt
@@ -1,0 +1,173 @@
+package com.woowa.data.remote.service
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.woowa.data.remote.model.response.ErrorResponse
+import com.woowa.data.remote.model.response.TokenDto
+import com.woowa.domain.model.Login
+import com.woowa.domain.model.Reissue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.create
+import java.io.File
+
+@ExperimentalCoroutinesApi
+internal class AuthenticationServiceTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var authenticationService: AuthenticationService
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        val moshi = Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+        authenticationService = Retrofit.Builder()
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .baseUrl(mockWebServer.url(""))
+            .build()
+            .create()
+    }
+
+    @Test
+    fun `인증되지 않은 사용자는 접근할 수 없다`() = runTest {
+        //given
+        val responseJson =
+            File("src/test/java/resources/auth/auth_fail_unauthorized.json").readText()
+        val response = MockResponse()
+            .setResponseCode(401)
+            .setBody(responseJson)
+        mockWebServer.enqueue(response)
+
+        assertThrows<HttpException> {
+            // when
+            val actualResponse = authenticationService.reissue(Reissue("", ""))
+
+            // then
+            assertAll(
+                { assertThat(actualResponse.success).isFalse() },
+                { assertThat(actualResponse.data).isNull() },
+                { assertThat(actualResponse.error.code).isEqualTo("HANDLE_UNAUTHORIZED") },
+                { assertThat(actualResponse.error.message).isEqualTo("인증되지 않은 사용자입니다.") },
+                { assertThat(actualResponse.error.errors).isEmpty() }
+            )
+        }
+    }
+
+    @Test
+    fun `인증 시 유효하지 않은 입력 값을 확인해야한다`() = runTest {
+        //given
+        val responseJson =
+            File("src/test/java/resources/auth/auth_fail_invalid_input_value.json").readText()
+        val response = MockResponse()
+            .setResponseCode(400)
+            .setBody(responseJson)
+        mockWebServer.enqueue(response)
+
+        assertThrows<HttpException> {
+            // when
+            val actualResponse = authenticationService.reissue(Reissue("", ""))
+
+            // then
+            assertAll(
+                { assertThat(actualResponse.success).isTrue() },
+                { assertThat(actualResponse.data).isNull() },
+                { assertThat(actualResponse.error.code).isEqualTo("INVALID_INPUT_VALUE") },
+                { assertThat(actualResponse.error.message).isEqualTo("유효하지 않은 입력 값입니다.") },
+                { assertThat(actualResponse.error.errors.first().field).isEqualTo("input-field") },
+                { assertThat(actualResponse.error.errors.first().value).isEqualTo("input-value") },
+                { assertThat(actualResponse.error.errors.first().reason).isEqualTo("error-reason") }
+            )
+        }
+    }
+
+    @Test
+    fun `로그인을 할 수 있다`() = runTest {
+        //given
+        val responseJson =
+            File("src/test/java/resources/auth/auth_success_login.json").readText()
+        val response = MockResponse()
+            .setResponseCode(200)
+            .setBody(responseJson)
+        mockWebServer.enqueue(response)
+
+        // when
+        val actualResponse = authenticationService.login(Login("taewoo", "123456"))
+
+        assertAll(
+            { assertThat(actualResponse.success).isTrue() },
+            {
+                assertThat(actualResponse.data).isEqualTo(
+                    TokenDto(
+                        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsInRva2VuX3R5cGUiOiJhY2Nlc3NfdG9rZW4iLCJpYXQiOjE2NjA1MzMxMzUsImV4cCI6MTY2MDUzNjczNX0.Dl7w6abygImRVfPzJJPze__p_Ig275E3x0n_fZsxCaU",
+                        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsInRva2VuX3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxNjYwNTMzMTM1LCJleHAiOjE2NjMxMjUxMzV9.UnMeqHym_-0DMCVWcFBdh2hGax378L6BmJhMHeo1ny8"
+                    )
+                )
+            },
+            { assertThat(actualResponse.error).isEqualTo(ErrorResponse.of()) }
+        )
+    }
+
+    @Test
+    fun `로그아웃을 할 수 있다`() = runTest {
+        //given
+        val responseJson =
+            File("src/test/java/resources/auth/auth_success_logout.json").readText()
+        val response = MockResponse()
+            .setResponseCode(200)
+            .setBody(responseJson)
+        mockWebServer.enqueue(response)
+
+        // when
+        val actualResponse = authenticationService.logout()
+
+        assertAll(
+            { assertThat(actualResponse.success).isTrue() },
+            { assertThat(actualResponse.data).isNull() },
+            { assertThat(actualResponse.error).isEqualTo(ErrorResponse.of()) }
+        )
+    }
+
+    @Test
+    fun `토큰을 재발급 받을 수 있다()`() = runTest {
+        //given
+        val responseJson =
+            File("src/test/java/resources/auth/auth_success_login.json").readText()
+        val response = MockResponse()
+            .setResponseCode(200)
+            .setBody(responseJson)
+        mockWebServer.enqueue(response)
+
+        // when
+        val actualResponse = authenticationService.reissue(
+            Reissue(
+                "",
+                "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsInRva2VuX3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxNjYwNTMzMTM1LCJleHAiOjE2NjMxMjUxMzV9.UnMeqHym_-0DMCVWcFBdh2hGax378L6BmJhMHeo1ny8"
+            )
+        )
+
+        assertAll(
+            { assertThat(actualResponse.success).isTrue() },
+            {
+                assertThat(actualResponse.data).isEqualTo(
+                    TokenDto(
+                        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsInRva2VuX3R5cGUiOiJhY2Nlc3NfdG9rZW4iLCJpYXQiOjE2NjA1MzMxMzUsImV4cCI6MTY2MDUzNjczNX0.Dl7w6abygImRVfPzJJPze__p_Ig275E3x0n_fZsxCaU",
+                        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsInRva2VuX3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxNjYwNTMzMTM1LCJleHAiOjE2NjMxMjUxMzV9.UnMeqHym_-0DMCVWcFBdh2hGax378L6BmJhMHeo1ny8"
+                    )
+                )
+            },
+            { assertThat(actualResponse.error).isEqualTo(ErrorResponse.of()) }
+        )
+    }
+}

--- a/data/src/test/java/resources/auth/auth_fail_invalid_input_value.json
+++ b/data/src/test/java/resources/auth/auth_fail_invalid_input_value.json
@@ -1,0 +1,14 @@
+{
+  "success" : true,
+  "error": {
+    "code": "INVALID_INPUT_VALUE",
+    "message": "유효하지 않은 입력 값입니다.",
+    "errors": [
+      {
+        "field": "input-field",
+        "value": "input-value",
+        "reason": "error-reason"
+      }
+    ]
+  }
+}

--- a/data/src/test/java/resources/auth/auth_fail_unauthorized.json
+++ b/data/src/test/java/resources/auth/auth_fail_unauthorized.json
@@ -1,0 +1,8 @@
+{
+  "success" : false,
+  "error": {
+    "code": "HANDLE_UNAUTHORIZED",
+    "message": "인증되지 않은 사용자입니다.",
+    "errors": []
+  }
+}

--- a/data/src/test/java/resources/auth/auth_success_login.json
+++ b/data/src/test/java/resources/auth/auth_success_login.json
@@ -1,0 +1,7 @@
+{
+  "success" : true,
+  "data" : {
+    "accessToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsInRva2VuX3R5cGUiOiJhY2Nlc3NfdG9rZW4iLCJpYXQiOjE2NjA1MzMxMzUsImV4cCI6MTY2MDUzNjczNX0.Dl7w6abygImRVfPzJJPze__p_Ig275E3x0n_fZsxCaU",
+    "refreshToken" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsInRva2VuX3R5cGUiOiJyZWZyZXNoX3Rva2VuIiwiaWF0IjoxNjYwNTMzMTM1LCJleHAiOjE2NjMxMjUxMzV9.UnMeqHym_-0DMCVWcFBdh2hGax378L6BmJhMHeo1ny8"
+  }
+}

--- a/data/src/test/java/resources/auth/auth_success_logout.json
+++ b/data/src/test/java/resources/auth/auth_success_logout.json
@@ -1,0 +1,3 @@
+{
+  "success" : true
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,9 +1,16 @@
 plugins {
     id("java-library")
     id("org.jetbrains.kotlin.jvm")
+    id("kotlin")
+    kotlin("kapt")
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+dependencies {
+    implementation(Library.Hilt.CORE)
+    kapt(Library.Hilt.COMPILER)
 }

--- a/domain/src/main/java/com/woowa/domain/model/ApiResult.kt
+++ b/domain/src/main/java/com/woowa/domain/model/ApiResult.kt
@@ -1,0 +1,3 @@
+package com.woowa.domain.model
+
+data class ApiResult<T>(val success: Boolean, val data: T? = null, val error: ErrorResult = ErrorResult.of())

--- a/domain/src/main/java/com/woowa/domain/model/ErrorResult.kt
+++ b/domain/src/main/java/com/woowa/domain/model/ErrorResult.kt
@@ -1,0 +1,18 @@
+package com.woowa.domain.model
+
+import com.woowa.domain.model.error.FieldError
+
+data class ErrorResult(val message: String, val errors: List<FieldError>) {
+
+    companion object {
+        fun of(): ErrorResult = ErrorResult(
+            message = "",
+            errors = emptyList()
+        )
+
+        fun of(message: String, errors: List<FieldError>) = ErrorResult(
+            message = message,
+            errors = errors
+        )
+    }
+}

--- a/domain/src/main/java/com/woowa/domain/model/Login.kt
+++ b/domain/src/main/java/com/woowa/domain/model/Login.kt
@@ -1,0 +1,3 @@
+package com.woowa.domain.model
+
+data class Login(val userName: String, val password: String)

--- a/domain/src/main/java/com/woowa/domain/model/Reissue.kt
+++ b/domain/src/main/java/com/woowa/domain/model/Reissue.kt
@@ -1,0 +1,3 @@
+package com.woowa.domain.model
+
+data class Reissue(val userName: String, val refreshToken: String)

--- a/domain/src/main/java/com/woowa/domain/model/Token.kt
+++ b/domain/src/main/java/com/woowa/domain/model/Token.kt
@@ -1,0 +1,3 @@
+package com.woowa.domain.model
+
+data class Token(val accessToken: String, val refreshToken: String)

--- a/domain/src/main/java/com/woowa/domain/model/error/FieldError.kt
+++ b/domain/src/main/java/com/woowa/domain/model/error/FieldError.kt
@@ -1,0 +1,3 @@
+package com.woowa.domain.model.error
+
+data class FieldError(val field: String, val value: String, val reason: String)

--- a/domain/src/main/java/com/woowa/domain/repository/AuthenticationRepository.kt
+++ b/domain/src/main/java/com/woowa/domain/repository/AuthenticationRepository.kt
@@ -1,0 +1,15 @@
+package com.woowa.domain.repository
+
+import com.woowa.domain.model.ApiResult
+import com.woowa.domain.model.Login
+import com.woowa.domain.model.Reissue
+import com.woowa.domain.model.Token
+
+interface AuthenticationRepository {
+
+    suspend fun login(login: Login): ApiResult<Token>
+
+    suspend fun logout(): ApiResult<*>
+
+    suspend fun reissue(reissue: Reissue): ApiResult<Token>
+}


### PR DESCRIPTION
## Issue

- closed #52 

## Description

- 인증 로직 처리
  - 로그인 성공 로직
  - 로그아웃 성공 로직
  - 재 발급 성공 로직
  - 유효성 평가 실패 경우 로직
  - 인증된 사람이 아닌 사람이 접근 시 로직

## 고민한 내용

- 서버와 일관성이 있는 response을 위해 ApiResponse을 만들었습니다. data 타입이 여러 경우가 존재하기 때문에 제네릭으로 처리했는데, data가 없는 응답도 존재하기 때문에 nullable 하게 처리했습니다. 이와 같이 ErrorField도 없는 응답이 존재합니다. 

  이 경우에는 디폴트 값을 of() 함수를 통해 ("", "", emptyList())로 처리했습니다. 두 가지 없는 경우에 대해서 nullable, qls 빈 공간으로 처리해서 일관성이 존재하지 않는 것 같아서 두가지 다 nullable로 처리하는게 괜찮을지, 아니면 에러에 대해선 empty처리하는 게 좋은지 이야기하면 좋을 것 같아요.