### PR TITLE
내가 쓴 글 조회 로직

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -11,6 +11,7 @@ object Version {
     const val FRAGMENT_KTX = "1.5.0"
     const val TEST_JUNIT = "1.1.3"
     const val ESPRESSO = "3.4.0"
+    const val PAGING3 = "3.1.1"
 
     const val JUNIT = "4.13.2"
 
@@ -41,6 +42,8 @@ object Library {
         const val FRAGMENT_KTX = "androidx.fragment:fragment-ktx:${Version.FRAGMENT_KTX}"
         const val TEST_JUNIT = "androidx.test.ext:junit:${Version.TEST_JUNIT}"
         const val ESPRESSO = "androidx.test.espresso:espresso-core:${Version.ESPRESSO}"
+        const val PAGING3 = "androidx.paging:paging-runtime-ktx:${Version.PAGING3}"
+        const val PAGING3_COMMON = "androidx.paging:paging-common:${Version.PAGING3}"
     }
 
     object Junit {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -16,6 +16,9 @@ tasks.test {
 
 dependencies {
     implementation(project(":domain"))
+
+    implementation(Library.AndroidX.PAGING3_COMMON)
+
     implementation(Library.Network.RETROFIT)
     implementation(Library.Network.MOSHI)
     implementation(Library.Network.MOSHI_KOTLIN)

--- a/data/src/main/java/com/woowa/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/woowa/data/di/RepositoryModule.kt
@@ -1,15 +1,13 @@
 package com.woowa.data.di
 
+import com.woowa.data.remote.repository.*
 import com.woowa.data.remote.repository.AuthenticationRepositoryImpl
 import com.woowa.data.remote.repository.CodeRepositoryImpl
-import com.woowa.data.remote.repository.MemberRepositoryImpl
-import com.woowa.domain.repository.CodeRepository
-import com.woowa.domain.repository.MemberRepository
 import com.woowa.data.remote.repository.EmailAuthenticationRepositoryImpl
-import com.woowa.domain.repository.EmailAuthenticationRepository
+import com.woowa.data.remote.repository.MemberRepositoryImpl
+import com.woowa.data.remote.repository.MyWroteRepositoryImpl
 import com.woowa.data.remote.repository.UniversityRepositoryImpl
-import com.woowa.domain.repository.AuthenticationRepository
-import com.woowa.domain.repository.UniversityRepository
+import com.woowa.domain.repository.*
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -26,11 +24,11 @@ internal interface RepositoryModule {
 
     @Binds
     @Singleton
-    fun provideCodeRepository(codeRepositoryImpl: CodeRepositoryImpl): CodeRepository
+    fun provideCode(codeRepositoryImpl: CodeRepositoryImpl): CodeRepository
 
     @Binds
     @Singleton
-    fun provideMemberRepository(memberRepositoryImpl: MemberRepositoryImpl): MemberRepository
+    fun provideMember(memberRepositoryImpl: MemberRepositoryImpl): MemberRepository
     
     @Binds
     @Singleton
@@ -39,4 +37,8 @@ internal interface RepositoryModule {
     @Binds
     @Singleton
     fun provideEmailAuthentication(emailAuthenticationRepositoryImpl: EmailAuthenticationRepositoryImpl): EmailAuthenticationRepository
+
+    @Binds
+    @Singleton
+    fun provideMyWrote(myWroteRepositoryImpl: MyWroteRepositoryImpl): MyWroteRepository
 }

--- a/data/src/main/java/com/woowa/data/di/ServiceModule.kt
+++ b/data/src/main/java/com/woowa/data/di/ServiceModule.kt
@@ -1,9 +1,11 @@
 package com.woowa.data.di
 
+import com.woowa.data.remote.service.*
 import com.woowa.data.remote.service.AuthenticationService
 import com.woowa.data.remote.service.CodeService
-import com.woowa.data.remote.service.MemberService
 import com.woowa.data.remote.service.EmailAuthenticationService
+import com.woowa.data.remote.service.MemberService
+import com.woowa.data.remote.service.MyWroteService
 import com.woowa.data.remote.service.UniversityService
 import dagger.Module
 import dagger.Provides
@@ -44,5 +46,11 @@ internal object ServiceModule {
     @Singleton
     fun provideEmailAuthenticationService(retrofit: Retrofit): EmailAuthenticationService {
         return retrofit.create(EmailAuthenticationService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideMyWroteService(retrofit: Retrofit): MyWroteService {
+        return retrofit.create(MyWroteService::class.java)
     }
 }

--- a/data/src/main/java/com/woowa/data/remote/model/response/member/MemberDto.kt
+++ b/data/src/main/java/com/woowa/data/remote/model/response/member/MemberDto.kt
@@ -1,7 +1,7 @@
-package com.woowa.data.remote.model.response
+package com.woowa.data.remote.model.response.member
 
-import com.woowa.domain.model.Member
-import com.woowa.domain.model.Personality
+import com.woowa.domain.model.member.Member
+import com.woowa.domain.model.member.Personality
 
 internal data class MemberDto(
     val id: Int,

--- a/data/src/main/java/com/woowa/data/remote/model/response/member/MemberUpdateDto.kt
+++ b/data/src/main/java/com/woowa/data/remote/model/response/member/MemberUpdateDto.kt
@@ -1,6 +1,6 @@
-package com.woowa.data.remote.model.response
+package com.woowa.data.remote.model.response.member
 
-import com.woowa.domain.model.MemberUpdate
+import com.woowa.domain.model.member.MemberUpdate
 
 internal data class MemberUpdateDto(val id: Int) {
     fun toMemberUpdate(): MemberUpdate = MemberUpdate(id)

--- a/data/src/main/java/com/woowa/data/remote/model/response/mywrote/MyWroteDto.kt
+++ b/data/src/main/java/com/woowa/data/remote/model/response/mywrote/MyWroteDto.kt
@@ -1,0 +1,55 @@
+package com.woowa.data.remote.model.response.mywrote
+
+import com.woowa.data.remote.model.response.CodeEnumDto
+import com.woowa.domain.model.mywrote.MyWrote
+import com.woowa.domain.model.mywrote.MyWroteContents
+
+internal data class MyWroteDto(
+    val page: Int,
+    val perSize: Int,
+    val totalCount: Int,
+    val totalPages: Int,
+    val prev: Boolean,
+    val next: Boolean,
+    val contents: List<MyWroteContentsDto>
+) {
+    fun toMyWrote(): MyWrote =
+        MyWrote(
+            page = page,
+            perSize = perSize,
+            totalCount = totalCount,
+            totalPages = totalPages,
+            prev = prev,
+            next = next,
+            contents = contents.map { it.toMyWroteContents() }
+        )
+}
+
+internal data class MyWroteContentsDto(
+    val id: Int,
+    val title: String,
+    val type: String,
+    val status: String,
+    val commentCount: Int,
+    val bookmarkCount: Int,
+    val projectName: String,
+    val professor: String? = null,
+    val field: CodeEnumDto? = null,
+    val fieldCategory: CodeEnumDto? = null,
+    val createdDate: String
+) {
+    fun toMyWroteContents(): MyWroteContents =
+        MyWroteContents(
+            id = id,
+            title = title,
+            type = type,
+            status = status,
+            commentCount = commentCount,
+            bookmarkCount = bookmarkCount,
+            projectName = projectName,
+            professor = professor,
+            field = field?.title,
+            fieldCategory = fieldCategory?.title,
+            createdDate = createdDate
+        )
+}

--- a/data/src/main/java/com/woowa/data/remote/repository/MemberRepositoryImpl.kt
+++ b/data/src/main/java/com/woowa/data/remote/repository/MemberRepositoryImpl.kt
@@ -2,6 +2,9 @@ package com.woowa.data.remote.repository
 
 import com.woowa.data.remote.soruce.MemberDataSource
 import com.woowa.domain.model.*
+import com.woowa.domain.model.member.Member
+import com.woowa.domain.model.member.MemberEdit
+import com.woowa.domain.model.member.MemberUpdate
 import com.woowa.domain.repository.MemberRepository
 import javax.inject.Inject
 

--- a/data/src/main/java/com/woowa/data/remote/repository/MyWroteRepositoryImpl.kt
+++ b/data/src/main/java/com/woowa/data/remote/repository/MyWroteRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.woowa.data.remote.repository
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import com.woowa.data.remote.soruce.paging.MyWrotePagingSource
+import com.woowa.data.remote.service.MyWroteService
+import com.woowa.domain.model.mywrote.MyWroteContents
+import com.woowa.domain.repository.MyWroteRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+internal class MyWroteRepositoryImpl @Inject constructor(
+    private val myWroteService: MyWroteService
+) : MyWroteRepository {
+
+    override suspend fun getMyWrote(status: String): Flow<PagingData<MyWroteContents>> {
+        return Pager(PagingConfig(pageSize = 10)) {
+            MyWrotePagingSource(myWroteService, status)
+        }.flow
+    }
+}

--- a/data/src/main/java/com/woowa/data/remote/service/MemberService.kt
+++ b/data/src/main/java/com/woowa/data/remote/service/MemberService.kt
@@ -1,9 +1,9 @@
 package com.woowa.data.remote.service
 
 import com.woowa.data.remote.model.response.ApiResponse
-import com.woowa.data.remote.model.response.MemberDto
-import com.woowa.data.remote.model.response.MemberUpdateDto
-import com.woowa.domain.model.MemberEdit
+import com.woowa.data.remote.model.response.member.MemberDto
+import com.woowa.data.remote.model.response.member.MemberUpdateDto
+import com.woowa.domain.model.member.MemberEdit
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PUT

--- a/data/src/main/java/com/woowa/data/remote/service/MyWroteService.kt
+++ b/data/src/main/java/com/woowa/data/remote/service/MyWroteService.kt
@@ -1,0 +1,16 @@
+package com.woowa.data.remote.service
+
+import com.woowa.data.remote.model.response.ApiResponse
+import com.woowa.data.remote.model.response.mywrote.MyWroteDto
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+internal interface MyWroteService {
+
+    @GET("recruiting/me")
+    suspend fun getMyWrote(
+        @Query("page") page: Int,
+        @Query("perSize") perSize: Int,
+        @Query("status") status: String
+    ): ApiResponse<MyWroteDto>
+}

--- a/data/src/main/java/com/woowa/data/remote/soruce/MemberDataSource.kt
+++ b/data/src/main/java/com/woowa/data/remote/soruce/MemberDataSource.kt
@@ -1,10 +1,10 @@
 package com.woowa.data.remote.soruce
 
 import com.woowa.data.remote.model.response.ApiResponse
-import com.woowa.data.remote.model.response.MemberDto
-import com.woowa.data.remote.model.response.MemberUpdateDto
+import com.woowa.data.remote.model.response.member.MemberDto
+import com.woowa.data.remote.model.response.member.MemberUpdateDto
 import com.woowa.data.remote.service.MemberService
-import com.woowa.domain.model.MemberEdit
+import com.woowa.domain.model.member.MemberEdit
 import javax.inject.Inject
 
 internal interface MemberDataSource {

--- a/data/src/main/java/com/woowa/data/remote/soruce/paging/MyWrotePagingSource.kt
+++ b/data/src/main/java/com/woowa/data/remote/soruce/paging/MyWrotePagingSource.kt
@@ -1,0 +1,62 @@
+package com.woowa.data.remote.soruce.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.woowa.data.remote.service.MyWroteService
+import com.woowa.domain.model.ApiResult
+import com.woowa.domain.model.ErrorResult
+import com.woowa.domain.model.mywrote.MyWroteContents
+import javax.inject.Inject
+
+internal class MyWrotePagingSource @Inject constructor(
+    private val myWroteService: MyWroteService,
+    private val status: String
+) : PagingSource<Int, MyWroteContents>() {
+
+    override fun getRefreshKey(state: PagingState<Int, MyWroteContents>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, MyWroteContents> {
+        val curPage = params.key ?: 1
+
+        return try {
+            val apiResponse = myWroteService.getMyWrote(curPage, PER_SIZE, status)
+            val apiResult = ApiResult(
+                success = apiResponse.success,
+                data = apiResponse.data?.toMyWrote(),
+                error = ErrorResult.of(apiResponse.error.message, apiResponse.error.errors)
+            )
+
+            if (apiResult.success) {
+                val data = apiResult.data ?: throw Exception("Empty data")
+                val endOfPaginationReached = !data.next
+
+                if (data.totalPages >= curPage) {
+                    LoadResult.Page(
+                        data = data.contents,
+                        prevKey = if (curPage == 1) null else curPage - 1,
+                        nextKey = if (endOfPaginationReached) null else curPage + 1
+                    )
+                } else {
+                    LoadResult.Page(
+                        data = emptyList(),
+                        prevKey = null,
+                        nextKey = null
+                    )
+                }
+            } else {
+                throw Exception("Network response failed")
+            }
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    companion object {
+        private const val PER_SIZE = 10
+    }
+}

--- a/data/src/test/java/com/woowa/data/remote/service/MemberServiceTest.kt
+++ b/data/src/test/java/com/woowa/data/remote/service/MemberServiceTest.kt
@@ -4,9 +4,9 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.woowa.data.remote.model.response.ErrorResponse
-import com.woowa.domain.model.Member
-import com.woowa.domain.model.MemberEdit
-import com.woowa.domain.model.Personality
+import com.woowa.domain.model.member.Member
+import com.woowa.domain.model.member.MemberEdit
+import com.woowa.domain.model.member.Personality
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import mockwebserver3.MockResponse

--- a/data/src/test/java/com/woowa/data/remote/service/MyWroteServiceTest.kt
+++ b/data/src/test/java/com/woowa/data/remote/service/MyWroteServiceTest.kt
@@ -1,0 +1,83 @@
+package com.woowa.data.remote.service
+
+import com.google.common.truth.Truth
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.woowa.data.remote.model.response.ErrorResponse
+import com.woowa.domain.model.mywrote.MyWrote
+import com.woowa.domain.model.mywrote.MyWroteContents
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.create
+import java.io.File
+
+@ExperimentalCoroutinesApi
+internal class MyWroteServiceTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var myWroteService: MyWroteService
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        val moshi = Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+        myWroteService = Retrofit.Builder()
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .baseUrl(mockWebServer.url(""))
+            .build()
+            .create()
+    }
+
+    @Test
+    fun `내가 쓴 글을 조회 할 수 있다`() = runTest {
+        // Given
+        val responseJson =
+            File("src/test/java/resources/mywrote/my_wrote_success.json").readText()
+        val response = MockResponse()
+            .setResponseCode(200)
+            .setBody(responseJson)
+        mockWebServer.enqueue(response)
+
+        // When
+        val actualResponse = myWroteService.getMyWrote(1, 10, "IN_PROGRESS")
+
+        // Then
+        val myWrote = MyWrote(
+            page = 0,
+            perSize = 5,
+            totalCount = 1,
+            totalPages = 1,
+            prev = false,
+            next = true,
+            contents = listOf(
+                MyWroteContents(
+                    id = 1,
+                    title = "모집글 제목 테스트",
+                    type = "LECTURE",
+                    status = "IN_PROGRESS",
+                    commentCount = 0,
+                    bookmarkCount = 0,
+                    projectName = "test-lecture-project-name",
+                    professor = "test-professor-name",
+                    field = null,
+                    fieldCategory = null,
+                    createdDate = "2022-08-21T13:00:00"
+                )
+            )
+        )
+        assertAll(
+            { Truth.assertThat(actualResponse.success).isTrue() },
+            { Truth.assertThat(actualResponse.data?.toMyWrote()).isEqualTo(myWrote) },
+            { Truth.assertThat(actualResponse.error).isEqualTo(ErrorResponse.of()) }
+        )
+    }
+}

--- a/data/src/test/java/resources/mywrote/my_wrote_success.json
+++ b/data/src/test/java/resources/mywrote/my_wrote_success.json
@@ -1,0 +1,24 @@
+{
+  "success": true,
+  "data": {
+    "page": 0,
+    "perSize": 5,
+    "totalCount": 1,
+    "totalPages": 1,
+    "prev": false,
+    "next": true,
+    "contents": [
+      {
+        "id": 1,
+        "title": "모집글 제목 테스트",
+        "type": "LECTURE",
+        "status": "IN_PROGRESS",
+        "commentCount": 0,
+        "bookmarkCount": 0,
+        "projectName": "test-lecture-project-name",
+        "professor": "test-professor-name",
+        "createdDate": "2022-08-21T13:00:00"
+      }
+    ]
+  }
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -11,6 +11,11 @@ java {
 }
 
 dependencies {
+    implementation(Library.AndroidX.PAGING3_COMMON)
+
+    implementation(Library.Coroutine.CORE)
+    implementation(Library.Coroutine.TEST)
+
     implementation(Library.Hilt.CORE)
     kapt(Library.Hilt.COMPILER)
 }

--- a/domain/src/main/java/com/woowa/domain/model/MemberUpdate.kt
+++ b/domain/src/main/java/com/woowa/domain/model/MemberUpdate.kt
@@ -1,3 +1,0 @@
-package com.woowa.domain.model
-
-data class MemberUpdate(val id: Int)

--- a/domain/src/main/java/com/woowa/domain/model/member/Member.kt
+++ b/domain/src/main/java/com/woowa/domain/model/member/Member.kt
@@ -1,4 +1,4 @@
-package com.woowa.domain.model
+package com.woowa.domain.model.member
 
 data class Member(
     val id: Int,

--- a/domain/src/main/java/com/woowa/domain/model/member/MemberEdit.kt
+++ b/domain/src/main/java/com/woowa/domain/model/member/MemberEdit.kt
@@ -1,4 +1,4 @@
-package com.woowa.domain.model
+package com.woowa.domain.model.member
 
 data class MemberEdit(
     val nickname: String,

--- a/domain/src/main/java/com/woowa/domain/model/member/MemberUpdate.kt
+++ b/domain/src/main/java/com/woowa/domain/model/member/MemberUpdate.kt
@@ -1,0 +1,3 @@
+package com.woowa.domain.model.member
+
+data class MemberUpdate(val id: Int)

--- a/domain/src/main/java/com/woowa/domain/model/mywrote/MyWrote.kt
+++ b/domain/src/main/java/com/woowa/domain/model/mywrote/MyWrote.kt
@@ -1,0 +1,25 @@
+package com.woowa.domain.model.mywrote
+
+data class MyWrote(
+    val page: Int,
+    val perSize: Int,
+    val totalCount: Int,
+    val totalPages: Int,
+    val prev: Boolean,
+    val next: Boolean,
+    val contents: List<MyWroteContents>
+)
+
+data class MyWroteContents(
+    val id: Int,
+    val title: String,
+    val type: String,
+    val status: String,
+    val commentCount: Int,
+    val bookmarkCount: Int,
+    val projectName: String,
+    val professor: String?,
+    val field: String?,
+    val fieldCategory: String?,
+    val createdDate: String
+)

--- a/domain/src/main/java/com/woowa/domain/repository/MemberRepository.kt
+++ b/domain/src/main/java/com/woowa/domain/repository/MemberRepository.kt
@@ -1,9 +1,9 @@
 package com.woowa.domain.repository
 
 import com.woowa.domain.model.ApiResult
-import com.woowa.domain.model.Member
-import com.woowa.domain.model.MemberEdit
-import com.woowa.domain.model.MemberUpdate
+import com.woowa.domain.model.member.Member
+import com.woowa.domain.model.member.MemberEdit
+import com.woowa.domain.model.member.MemberUpdate
 
 interface MemberRepository {
 

--- a/domain/src/main/java/com/woowa/domain/repository/MyWroteRepository.kt
+++ b/domain/src/main/java/com/woowa/domain/repository/MyWroteRepository.kt
@@ -1,0 +1,10 @@
+package com.woowa.domain.repository
+
+import androidx.paging.PagingData
+import com.woowa.domain.model.mywrote.MyWroteContents
+import kotlinx.coroutines.flow.Flow
+
+interface MyWroteRepository {
+
+    suspend fun getMyWrote(status: String): Flow<PagingData<MyWroteContents>>
+}


### PR DESCRIPTION
## Issue

- closed #60 

## Description

- 내가 쓴 글 조회 로직 처리
- 로직 테스트코드 작성
- Paging3 라이브러리 추가
  - PagingSource 코드 작성 → Domain

## 고민한 내용
내가 쓴 글 객체를 보시면 파라미터 **professor**와 **field**/**fieldCategory**의 데이터가 **type**(**강의**, **사이드**)에 따라 
안내려올 때가 있습니다. 그래서 일단 해당 파라미터들은 **nullable**하도록 처리했습니다.

**Paging3** 라이브러리를 추가했습니다!
_paging-runtime_ 라이브러리를 이용하게 되면 안드로이드 라이브러리를 사용하는 모듈에서만
사용가능한 문제가 있어 _paging-common_ 라이브러리를 추가해  **Data**, **Domain** 계층에서
사용할 수 있도록 했습니다.
Slack에서도 말씀드렸다시피 Paging3 구조상의 문제로 Domain 계층에서 **Flow + PagingData** 형태로
작성해야할 것 같습니다!
