### PR TITLE
enum 클래스 설정

### DIFF
--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -17,5 +17,6 @@ dependencies {
     implementation(Library.Coroutine.TEST)
 
     implementation(Library.Hilt.CORE)
+    implementation(Library.AndroidX.PAGING3_COMMON)
     kapt(Library.Hilt.COMPILER)
 }

--- a/domain/src/main/java/com/woowa/domain/model/code/ActivityArea.kt
+++ b/domain/src/main/java/com/woowa/domain/model/code/ActivityArea.kt
@@ -1,0 +1,20 @@
+package com.woowa.domain.model.code
+
+enum class ActivityArea(val kor: String) {
+    ONLINE("온라인"),
+    SEOUL("서울"),
+    GYEONGGI("경기"),
+    GANGWON("강원"),
+    INCHEON("인천"),
+    BUSAN("부산"),
+    DAEGU("대구"),
+    ULSAN("울산"),
+    CHUNGCHEONGBUKDO("충청북도"),
+    CHUNGCHEONGNAMDO("충청남도"),
+    GYEONGSANGBUKDO("경상북도"),
+    JEOLLABUKDO("전라북도"),
+    JEOLLANAMDO("전라남도"),
+    GYEONGSANGNAMDO("경상남도"),
+    GWANGJU("광주"),
+    JEJUDO("제주도")
+}

--- a/domain/src/main/java/com/woowa/domain/model/code/DayOfWeek.kt
+++ b/domain/src/main/java/com/woowa/domain/model/code/DayOfWeek.kt
@@ -1,0 +1,11 @@
+package com.woowa.domain.model.code
+
+enum class DayOfWeek(val title: String) {
+    MON("월"),
+    TUE("화"),
+    WED("수"),
+    THUR("목"),
+    FRI("금"),
+    SAT("토"),
+    SUN("일")
+}

--- a/domain/src/main/java/com/woowa/domain/model/code/Field.kt
+++ b/domain/src/main/java/com/woowa/domain/model/code/Field.kt
@@ -1,0 +1,13 @@
+package com.woowa.domain.model.code
+
+enum class Field(val title: String) {
+    AD_MARKETING("광고/마케팅"),
+    PLANNING_IDEA("기획/아이디어"),
+    DESIGN("디자인"),
+    IT_SW_GAME("IT/소프트웨어/게임"),
+    MEDIA("미디어"),
+    ART_MUSIC_PHYSICAL("예체능"),
+    LANGUAGE("어학"),
+    FINANCE_ACCOUNTING("금융/회계"),
+    ETC("기타")
+}

--- a/domain/src/main/java/com/woowa/domain/model/code/FieldCategory.kt
+++ b/domain/src/main/java/com/woowa/domain/model/code/FieldCategory.kt
@@ -1,0 +1,8 @@
+package com.woowa.domain.model.code
+
+enum class FieldCategory(val title: String) {
+    CONTEST("공모전"),
+    EXTRA_ACTIVITY("대외활동"),
+    STUDY("스터디"),
+    CLUB("동아리")
+}

--- a/domain/src/main/java/com/woowa/domain/model/code/PersonalityAdjective.kt
+++ b/domain/src/main/java/com/woowa/domain/model/code/PersonalityAdjective.kt
@@ -1,0 +1,13 @@
+package com.woowa.domain.model.code
+
+enum class PersonalityAdjective(val title: String) {
+    LOGICAL("논리적인"),
+    PRECISE("꼼꼼한"),
+    PLANNED("계획적인"),
+    QUICK_WORKING("일처리가 빠른"),
+    CHEERFUL("쾌활한"),
+    CREATIVE("창의적인"),
+    SINCERE("성실한"),
+    GOAL_ORIENTED("목표지향적인"),
+    PERSISTENT("끈기있는")
+}

--- a/domain/src/main/java/com/woowa/domain/model/code/PersonalityNoun.kt
+++ b/domain/src/main/java/com/woowa/domain/model/code/PersonalityNoun.kt
@@ -1,0 +1,13 @@
+package com.woowa.domain.model.code
+
+enum class PersonalityNoun(val title: String) {
+    INVENTOR("발명가"),
+    LEADER("리더"),
+    FOLLOWER("팔로워"),
+    PERFECTIONIST("완벽주의자"),
+    COMMUNICATOR("커뮤니케이터"),
+    ADVENTURER("모험가"),
+    ANALYST("분석가"),
+    MEDIATOR("중재자"),
+    JACK_OF_ALL_TRADES("만능재주꾼")
+}

--- a/domain/src/main/java/com/woowa/domain/model/code/ReviewTag.kt
+++ b/domain/src/main/java/com/woowa/domain/model/code/ReviewTag.kt
@@ -1,0 +1,13 @@
+package com.woowa.domain.model.code
+
+enum class ReviewTag(val title: String) {
+    RESPONSIBILITY("책임감 굿"),
+    PUNCTUALITY("마감을 칼같이"),
+    MOOD_MAKER("분위기 메이커"),
+    TIME_MANNERS("시간매너 끝판왕"),
+    POSITIVE("긍정 태도왕"),
+    IDEA("아이디어 요정"),
+    FEEDBACK("활발한 피드백"),
+    DECISIVE("속전속결 결정왕"),
+    LIKE_MINE("남의 일도 내 일같이")
+}

--- a/domain/src/main/java/com/woowa/domain/model/code/Type.kt
+++ b/domain/src/main/java/com/woowa/domain/model/code/Type.kt
@@ -1,0 +1,6 @@
+package com.woowa.domain.model.code
+
+enum class Type {
+    SIDE,
+    LECTURE
+}

--- a/domain/src/main/java/com/woowa/domain/model/code/VoteType.kt
+++ b/domain/src/main/java/com/woowa/domain/model/code/VoteType.kt
@@ -1,0 +1,6 @@
+package com.woowa.domain.model.code
+
+enum class VoteType(val title: String) {
+    PROJECT_COMPLETE("팀플 완료 투표"),
+    EXPEL("내보내기 투표")
+}


### PR DESCRIPTION
## Issue

- closed #62 

## Description

- 고정되어있는 데이터 enum class로 설정
  - 지역(ActivityArea)
  - 요일(DayOfWeek)
  - 필드(Field)
  - 카테고리(FieldCategory)
  - 성격(Adjective)
  - 성격(Noun)
  - 리뷰태그(ReviewTag)
  - 타입(SIDE, LECTURE)
  - 투표타입(VoteType)